### PR TITLE
IGNITE-3601 Read-only optimistic transaction shouldn't throw an excep…

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxLocal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxLocal.java
@@ -953,7 +953,7 @@ public class GridNearTxLocal extends GridDhtTxLocalAdapter {
      * @return {@code True} if 'fast finish' path can be used for transaction completion.
      */
     private boolean fastFinish() {
-        return writeMap().isEmpty() && ((optimistic() && !serializable()) || readMap().isEmpty());
+        return writeMap().isEmpty() && (optimistic() || readMap().isEmpty());
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheGetEntryAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheGetEntryAbstractTest.java
@@ -40,6 +40,7 @@ import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.transactions.Transaction;
 import org.apache.ignite.transactions.TransactionConcurrency;
 import org.apache.ignite.transactions.TransactionIsolation;
+import org.apache.ignite.transactions.TransactionOptimisticException;
 import org.jetbrains.annotations.Nullable;
 
 import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
@@ -52,6 +53,7 @@ import static org.apache.ignite.transactions.TransactionConcurrency.OPTIMISTIC;
 import static org.apache.ignite.transactions.TransactionConcurrency.PESSIMISTIC;
 import static org.apache.ignite.transactions.TransactionIsolation.READ_COMMITTED;
 import static org.apache.ignite.transactions.TransactionIsolation.REPEATABLE_READ;
+import static org.apache.ignite.transactions.TransactionIsolation.SERIALIZABLE;
 
 /**
  * Test getEntry and getEntries methods.
@@ -247,11 +249,47 @@ public abstract class CacheGetEntryAbstractTest extends GridCacheAbstractSelfTes
 
                 testConcurrentTx(cache, PESSIMISTIC, REPEATABLE_READ, oneEntry);
                 testConcurrentTx(cache, PESSIMISTIC, READ_COMMITTED, oneEntry);
+
+                testConcurrentOptimisticTxGet(cache, REPEATABLE_READ);
+                testConcurrentOptimisticTxGet(cache, READ_COMMITTED);
+                testConcurrentOptimisticTxGet(cache, SERIALIZABLE);
             }
         }
         finally {
             cache.destroy();
         }
+    }
+
+    /**
+     * @param cache Cache.
+     * @param txIsolation Transaction isolation.
+     * @throws Exception If failed.
+     */
+    private void testConcurrentOptimisticTxGet(final IgniteCache<Integer, TestValue> cache,
+        final TransactionIsolation txIsolation) throws Exception {
+        GridTestUtils.runMultiThreaded(new Runnable() {
+            @Override public void run() {
+                final int key = 42;
+
+                IgniteTransactions txs = grid(0).transactions();
+
+                cache.put(key, new TestValue(key));
+
+                long stopTime = System.currentTimeMillis() + 3000;
+
+                while (System.currentTimeMillis() < stopTime) {
+                    try (Transaction tx = txs.txStart(OPTIMISTIC, txIsolation)) {
+                        cache.get(key);
+
+                        tx.commit();
+                    }
+                    catch (TransactionOptimisticException e) {
+                        assertTrue("Should not throw optimistic exception in only read TX. Tx isolation: "
+                            + txIsolation, false);
+                    }
+                }
+            }
+        }, 10, "tx-thread");
     }
 
     /**


### PR DESCRIPTION
…tion if entry version was not changed.

Read only serializable transactions are commiting without check.