### PR TITLE
IGNITE-6888: attach caches involved in query to statement

### DIFF
--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2StatementCache.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2StatementCache.java
@@ -20,14 +20,13 @@ package org.apache.ignite.internal.processors.query.h2;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.jetbrains.annotations.Nullable;
 
-import java.sql.PreparedStatement;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
  * Statement cache. LRU eviction policy is used. Not thread-safe.
  */
-class H2StatementCache {
+final class H2StatementCache {
     /** Last usage. */
     private volatile long lastUsage;
 
@@ -58,8 +57,8 @@ class H2StatementCache {
      * @param key Key associated with statement.
      * @param stmt Statement which will be cached.
      */
-    void put(H2CachedStatementKey key, PreparedStatement stmt) {
-        lruStmtCache.put(key, new StatementWithMeta(stmt));
+    void put(H2CachedStatementKey key, StatementWithMeta stmt) {
+        lruStmtCache.put(key, stmt);
     }
 
     /**

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -409,7 +409,7 @@ public class IgniteH2Indexing implements GridQueryIndexing {
 
             stmt = prepare0(c, sql);
 
-            cache.put(key, stmt);
+            cache.put(key, new StatementWithMeta(stmt));
 
             return stmt;
         }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -397,7 +397,7 @@ public class IgniteH2Indexing implements GridQueryIndexing {
 
             PreparedStatement stmt = cache.get(key);
 
-            if (stmt != null && !stmt.isClosed() && !((JdbcStatement)stmt).isCancelled() &&
+            if (stmt != null && !stmt.isClosed() && !stmt.unwrap(JdbcStatement.class).isCancelled() &&
                 !GridSqlQueryParser.prepared(stmt).needRecompile()) {
                 assert stmt.getConnection() == c;
 

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -396,7 +396,7 @@ public class IgniteH2Indexing implements GridQueryIndexing {
 
             H2CachedStatementKey key = new H2CachedStatementKey(c.getSchema(), sql);
 
-            PreparedStatement stmt = cache.get(key);
+            StatementWithMeta stmt = cache.get(key);
 
             if (stmt != null && !stmt.isClosed() && !stmt.unwrap(JdbcStatement.class).isCancelled() &&
                 !GridSqlQueryParser.prepared(stmt).needRecompile()) {
@@ -408,9 +408,9 @@ public class IgniteH2Indexing implements GridQueryIndexing {
             if (cachedOnly)
                 return null;
 
-            stmt = prepare0(c, sql);
+            stmt = new StatementWithMeta(prepare0(c, sql));
 
-            cache.put(key, new StatementWithMeta(stmt));
+            cache.put(key, stmt);
 
             return stmt;
         }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/StatementWithMeta.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/StatementWithMeta.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * PreparedStatement with extended capability to store additional meta information.
  */
-class StatementWithMeta implements PreparedStatement {
+final class StatementWithMeta implements PreparedStatement {
     /** */
     private static final AtomicInteger metaIdGenerator = new AtomicInteger();
     /** */

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/StatementWithMeta.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/StatementWithMeta.java
@@ -23,7 +23,25 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.URL;
-import java.sql.*;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLType;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -41,6 +59,8 @@ final class StatementWithMeta implements PreparedStatement {
     private final PreparedStatement delegate;
 
     StatementWithMeta(PreparedStatement delegate) {
+        assert !(delegate instanceof StatementWithMeta);
+
         this.delegate = delegate;
     }
 
@@ -64,8 +84,10 @@ final class StatementWithMeta implements PreparedStatement {
      * @param metaObj Meta object.
      */
     void putMeta(int id, Object metaObj) {
-        if (meta == null || id >= meta.length)
+        if (meta == null)
             meta = new Object[id + 1];
+        else if (id >= meta.length)
+            meta = Arrays.copyOf(meta, id + 1);
 
         meta[id] = metaObj;
     }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/StatementWithMeta.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/StatementWithMeta.java
@@ -1,0 +1,624 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query.h2;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.*;
+import java.util.Calendar;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * PreparedStatement with extended capability to store additional meta information.
+ */
+class StatementWithMeta implements PreparedStatement {
+    /** */
+    private static final AtomicInteger metaIdGenerator = new AtomicInteger();
+    /** */
+    static final int INVOLVED_CACHES = metaIdGenerator.getAndIncrement();
+    /** */
+    private Object[] meta = null;
+    /** */
+    private final PreparedStatement delegate;
+
+    StatementWithMeta(PreparedStatement delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Gets meta for given id.
+     *
+     * @param id Meta id.
+     * @param <T> Meta object type.
+     * @return Meta object.
+     */
+    @SuppressWarnings("unchecked")
+    @Nullable
+    <T> T meta(int id) {
+        return meta != null && id < meta.length ? (T) meta[id] : null;
+    }
+
+    /**
+     * Puts meta for given id.
+     *
+     * @param id Meta id.
+     * @param metaObj Meta object.
+     */
+    void putMeta(int id, Object metaObj) {
+        if (meta == null || id >= meta.length)
+            meta = new Object[id + 1];
+
+        meta[id] = metaObj;
+    }
+
+    @Override
+    public ResultSet executeQuery() throws SQLException {
+        return delegate.executeQuery();
+    }
+
+    @Override
+    public int executeUpdate() throws SQLException {
+        return delegate.executeUpdate();
+    }
+
+    @Override
+    public void setNull(int parameterIndex, int sqlType) throws SQLException {
+        delegate.setNull(parameterIndex, sqlType);
+    }
+
+    @Override
+    public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+        delegate.setBoolean(parameterIndex, x);
+    }
+
+    @Override
+    public void setByte(int parameterIndex, byte x) throws SQLException {
+        delegate.setByte(parameterIndex, x);
+    }
+
+    @Override
+    public void setShort(int parameterIndex, short x) throws SQLException {
+        delegate.setShort(parameterIndex, x);
+    }
+
+    @Override
+    public void setInt(int parameterIndex, int x) throws SQLException {
+        delegate.setInt(parameterIndex, x);
+    }
+
+    @Override
+    public void setLong(int parameterIndex, long x) throws SQLException {
+        delegate.setLong(parameterIndex, x);
+    }
+
+    @Override
+    public void setFloat(int parameterIndex, float x) throws SQLException {
+        delegate.setFloat(parameterIndex, x);
+    }
+
+    @Override
+    public void setDouble(int parameterIndex, double x) throws SQLException {
+        delegate.setDouble(parameterIndex, x);
+    }
+
+    @Override
+    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+        delegate.setBigDecimal(parameterIndex, x);
+    }
+
+    @Override
+    public void setString(int parameterIndex, String x) throws SQLException {
+        delegate.setString(parameterIndex, x);
+    }
+
+    @Override
+    public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+        delegate.setBytes(parameterIndex, x);
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date x) throws SQLException {
+        delegate.setDate(parameterIndex, x);
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time x) throws SQLException {
+        delegate.setTime(parameterIndex, x);
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+        delegate.setTimestamp(parameterIndex, x);
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        delegate.setAsciiStream(parameterIndex, x, length);
+    }
+
+    @Override
+    @Deprecated
+    public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        delegate.setUnicodeStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        delegate.setBinaryStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void clearParameters() throws SQLException {
+        delegate.clearParameters();
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+        delegate.setObject(parameterIndex, x, targetSqlType);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x) throws SQLException {
+        delegate.setObject(parameterIndex, x);
+    }
+
+    @Override
+    public boolean execute() throws SQLException {
+        return delegate.execute();
+    }
+
+    @Override
+    public void addBatch() throws SQLException {
+        delegate.addBatch();
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
+        delegate.setCharacterStream(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setRef(int parameterIndex, Ref x) throws SQLException {
+        delegate.setRef(parameterIndex, x);
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, Blob x) throws SQLException {
+        delegate.setBlob(parameterIndex, x);
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Clob x) throws SQLException {
+        delegate.setClob(parameterIndex, x);
+    }
+
+    @Override
+    public void setArray(int parameterIndex, Array x) throws SQLException {
+        delegate.setArray(parameterIndex, x);
+    }
+
+    @Override
+    public ResultSetMetaData getMetaData() throws SQLException {
+        return delegate.getMetaData();
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+        delegate.setDate(parameterIndex, x, cal);
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+        delegate.setTime(parameterIndex, x, cal);
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+        delegate.setTimestamp(parameterIndex, x, cal);
+    }
+
+    @Override
+    public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+        delegate.setNull(parameterIndex, sqlType, typeName);
+    }
+
+    @Override
+    public void setURL(int parameterIndex, URL x) throws SQLException {
+        delegate.setURL(parameterIndex, x);
+    }
+
+    @Override
+    public ParameterMetaData getParameterMetaData() throws SQLException {
+        return delegate.getParameterMetaData();
+    }
+
+    @Override
+    public void setRowId(int parameterIndex, RowId x) throws SQLException {
+        delegate.setRowId(parameterIndex, x);
+    }
+
+    @Override
+    public void setNString(int parameterIndex, String value) throws SQLException {
+        delegate.setNString(parameterIndex, value);
+    }
+
+    @Override
+    public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
+        delegate.setNCharacterStream(parameterIndex, value, length);
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, NClob value) throws SQLException {
+        delegate.setNClob(parameterIndex, value);
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+        delegate.setClob(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
+        delegate.setBlob(parameterIndex, inputStream, length);
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+        delegate.setNClob(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+        delegate.setSQLXML(parameterIndex, xmlObject);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
+        delegate.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+        delegate.setAsciiStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+        delegate.setBinaryStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
+        delegate.setCharacterStream(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+        delegate.setAsciiStream(parameterIndex, x);
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+        delegate.setBinaryStream(parameterIndex, x);
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+        delegate.setCharacterStream(parameterIndex, reader);
+    }
+
+    @Override
+    public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+        delegate.setNCharacterStream(parameterIndex, value);
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Reader reader) throws SQLException {
+        delegate.setClob(parameterIndex, reader);
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+        delegate.setBlob(parameterIndex, inputStream);
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+        delegate.setNClob(parameterIndex, reader);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
+        delegate.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+        delegate.setObject(parameterIndex, x, targetSqlType);
+    }
+
+    @Override
+    public long executeLargeUpdate() throws SQLException {
+        return delegate.executeLargeUpdate();
+    }
+
+    @Override
+    public ResultSet executeQuery(String sql) throws SQLException {
+        return delegate.executeQuery(sql);
+    }
+
+    @Override
+    public int executeUpdate(String sql) throws SQLException {
+        return delegate.executeUpdate(sql);
+    }
+
+    @Override
+    public void close() throws SQLException {
+        delegate.close();
+    }
+
+    @Override
+    public int getMaxFieldSize() throws SQLException {
+        return delegate.getMaxFieldSize();
+    }
+
+    @Override
+    public void setMaxFieldSize(int max) throws SQLException {
+        delegate.setMaxFieldSize(max);
+    }
+
+    @Override
+    public int getMaxRows() throws SQLException {
+        return delegate.getMaxRows();
+    }
+
+    @Override
+    public void setMaxRows(int max) throws SQLException {
+        delegate.setMaxRows(max);
+    }
+
+    @Override
+    public void setEscapeProcessing(boolean enable) throws SQLException {
+        delegate.setEscapeProcessing(enable);
+    }
+
+    @Override
+    public int getQueryTimeout() throws SQLException {
+        return delegate.getQueryTimeout();
+    }
+
+    @Override
+    public void setQueryTimeout(int seconds) throws SQLException {
+        delegate.setQueryTimeout(seconds);
+    }
+
+    @Override
+    public void cancel() throws SQLException {
+        delegate.cancel();
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        return delegate.getWarnings();
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        delegate.clearWarnings();
+    }
+
+    @Override
+    public void setCursorName(String name) throws SQLException {
+        delegate.setCursorName(name);
+    }
+
+    @Override
+    public boolean execute(String sql) throws SQLException {
+        return delegate.execute(sql);
+    }
+
+    @Override
+    public ResultSet getResultSet() throws SQLException {
+        return delegate.getResultSet();
+    }
+
+    @Override
+    public int getUpdateCount() throws SQLException {
+        return delegate.getUpdateCount();
+    }
+
+    @Override
+    public boolean getMoreResults() throws SQLException {
+        return delegate.getMoreResults();
+    }
+
+    @Override
+    public void setFetchDirection(int direction) throws SQLException {
+        delegate.setFetchDirection(direction);
+    }
+
+    @Override
+    public int getFetchDirection() throws SQLException {
+        return delegate.getFetchDirection();
+    }
+
+    @Override
+    public void setFetchSize(int rows) throws SQLException {
+        delegate.setFetchSize(rows);
+    }
+
+    @Override
+    public int getFetchSize() throws SQLException {
+        return delegate.getFetchSize();
+    }
+
+    @Override
+    public int getResultSetConcurrency() throws SQLException {
+        return delegate.getResultSetConcurrency();
+    }
+
+    @Override
+    public int getResultSetType() throws SQLException {
+        return delegate.getResultSetType();
+    }
+
+    @Override
+    public void addBatch(String sql) throws SQLException {
+        delegate.addBatch(sql);
+    }
+
+    @Override
+    public void clearBatch() throws SQLException {
+        delegate.clearBatch();
+    }
+
+    @Override
+    public int[] executeBatch() throws SQLException {
+        return delegate.executeBatch();
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return delegate.getConnection();
+    }
+
+    @Override
+    public boolean getMoreResults(int current) throws SQLException {
+        return delegate.getMoreResults(current);
+    }
+
+    @Override
+    public ResultSet getGeneratedKeys() throws SQLException {
+        return delegate.getGeneratedKeys();
+    }
+
+    @Override
+    public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+        return delegate.executeUpdate(sql, autoGeneratedKeys);
+    }
+
+    @Override
+    public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+        return delegate.executeUpdate(sql, columnIndexes);
+    }
+
+    @Override
+    public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+        return delegate.executeUpdate(sql, columnNames);
+    }
+
+    @Override
+    public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+        return delegate.execute(sql, autoGeneratedKeys);
+    }
+
+    @Override
+    public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+        return delegate.execute(sql, columnIndexes);
+    }
+
+    @Override
+    public boolean execute(String sql, String[] columnNames) throws SQLException {
+        return delegate.execute(sql, columnNames);
+    }
+
+    @Override
+    public int getResultSetHoldability() throws SQLException {
+        return delegate.getResultSetHoldability();
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return delegate.isClosed();
+    }
+
+    @Override
+    public void setPoolable(boolean poolable) throws SQLException {
+        delegate.setPoolable(poolable);
+    }
+
+    @Override
+    public boolean isPoolable() throws SQLException {
+        return delegate.isPoolable();
+    }
+
+    @Override
+    public void closeOnCompletion() throws SQLException {
+        delegate.closeOnCompletion();
+    }
+
+    @Override
+    public boolean isCloseOnCompletion() throws SQLException {
+        return delegate.isCloseOnCompletion();
+    }
+
+    @Override
+    public long getLargeUpdateCount() throws SQLException {
+        return delegate.getLargeUpdateCount();
+    }
+
+    @Override
+    public void setLargeMaxRows(long max) throws SQLException {
+        delegate.setLargeMaxRows(max);
+    }
+
+    @Override
+    public long getLargeMaxRows() throws SQLException {
+        return delegate.getLargeMaxRows();
+    }
+
+    @Override
+    public long[] executeLargeBatch() throws SQLException {
+        return delegate.executeLargeBatch();
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql) throws SQLException {
+        return delegate.executeLargeUpdate(sql);
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+        return delegate.executeLargeUpdate(sql, autoGeneratedKeys);
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql, int[] columnIndexes) throws SQLException {
+        return delegate.executeLargeUpdate(sql, columnIndexes);
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql, String[] columnNames) throws SQLException {
+        return delegate.executeLargeUpdate(sql, columnNames);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return iface == StatementWithMeta.class ? (T) this : delegate.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return iface == StatementWithMeta.class ? true : delegate.isWrapperFor(iface);
+    }
+}

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sql/GridSqlQueryParser.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sql/GridSqlQueryParser.java
@@ -1791,7 +1791,7 @@ public class GridSqlQueryParser {
     /**
      * @return H2 to Grid objects map.
      */
-    public Map objectsMap() {
+    public Map<Object, Object> objectsMap() {
         return h2ObjToGridObj;
     }
 

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sql/GridSqlQueryParser.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sql/GridSqlQueryParser.java
@@ -570,7 +570,7 @@ public class GridSqlQueryParser {
      * @return Parsed select.
      */
     public static PreparedWithRemaining preparedWithRemaining(PreparedStatement stmt) {
-        Command cmd = COMMAND.get((JdbcPreparedStatement)stmt);
+        Command cmd = extractCommand(stmt);
 
         if (cmd instanceof CommandContainer)
             return new PreparedWithRemaining(PREPARED.get(cmd), null);

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/H2StatementCacheSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/H2StatementCacheSelfTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query.h2;
+
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+
+public class H2StatementCacheSelfTest extends GridCommonAbstractTest {
+    public void testEviction() throws Exception {
+        H2StatementCache stmtCache = new H2StatementCache(1);
+        H2CachedStatementKey key1 = new H2CachedStatementKey("", "1");
+        StatementWithMeta stmt1 = stmt();
+        stmtCache.put(key1, stmt1);
+
+        assertSame(stmt1, stmtCache.get(key1));
+
+        stmtCache.put(new H2CachedStatementKey("mydb", "2"), stmt());
+
+        assertNull(stmtCache.get(key1));
+    }
+
+    public void testLruEvictionInStoreOrder() throws Exception {
+        H2StatementCache stmtCache = new H2StatementCache(2);
+
+        H2CachedStatementKey key1 = new H2CachedStatementKey("", "1");
+        H2CachedStatementKey key2 = new H2CachedStatementKey("", "2");
+        stmtCache.put(key1, stmt());
+        stmtCache.put(key2, stmt());
+
+        stmtCache.put(new H2CachedStatementKey("", "3"), stmt());
+
+        assertNull(stmtCache.get(key1));
+    }
+
+    public void testLruEvictionInAccessOrder() throws Exception {
+        H2StatementCache stmtCache = new H2StatementCache(2);
+
+        H2CachedStatementKey key1 = new H2CachedStatementKey("", "1");
+        H2CachedStatementKey key2 = new H2CachedStatementKey("", "2");
+        stmtCache.put(key1, stmt());
+        stmtCache.put(key2, stmt());
+        stmtCache.get(key1);
+
+        stmtCache.put(new H2CachedStatementKey("", "3"), stmt());
+
+        assertNull(stmtCache.get(key2));
+    }
+
+    private static StatementWithMeta stmt() {
+        return new StatementWithMeta(null);
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/StatementWithMetaSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/StatementWithMetaSelfTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query.h2;
+
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+
+public class StatementWithMetaSelfTest extends GridCommonAbstractTest {
+    public void testStoringMeta() {
+        StatementWithMeta stmt = stmt();
+        stmt.putMeta(0, "0");
+
+        assertEquals("0", stmt.meta(0));
+    }
+
+    public void testStoringMoreMetaKeepsExisting() {
+        StatementWithMeta stmt = stmt();
+        stmt.putMeta(0, "0");
+        stmt.putMeta(1, "1");
+
+        assertEquals("0", stmt.meta(0));
+        assertEquals("1", stmt.meta(1));
+    }
+
+    private static StatementWithMeta stmt() {
+        return new StatementWithMeta(null);
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheQuerySelfTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheQuerySelfTestSuite.java
@@ -168,9 +168,11 @@ import org.apache.ignite.internal.processors.query.SqlSchemaSelfTest;
 import org.apache.ignite.internal.processors.query.h2.GridH2IndexingInMemSelfTest;
 import org.apache.ignite.internal.processors.query.h2.GridH2IndexingOffheapSelfTest;
 import org.apache.ignite.internal.processors.query.h2.GridIndexRebuildSelfTest;
+import org.apache.ignite.internal.processors.query.h2.H2StatementCacheSelfTest;
 import org.apache.ignite.internal.processors.query.h2.IgniteSqlBigIntegerKeyTest;
 import org.apache.ignite.internal.processors.query.h2.IgniteSqlQueryMinMaxTest;
 import org.apache.ignite.internal.processors.query.h2.ObjectPoolSelfTest;
+import org.apache.ignite.internal.processors.query.h2.StatementWithMetaSelfTest;
 import org.apache.ignite.internal.processors.query.h2.sql.BaseH2CompareQueryTest;
 import org.apache.ignite.internal.processors.query.h2.sql.GridQueryParsingTest;
 import org.apache.ignite.internal.processors.query.h2.sql.H2CompareBigQueryDistributedJoinsTest;
@@ -430,6 +432,8 @@ public class IgniteCacheQuerySelfTestSuite extends TestSuite {
         suite.addTestSuite(SqlUserCommandSelfTest.class);
 
         suite.addTestSuite(ObjectPoolSelfTest.class);
+        suite.addTestSuite(H2StatementCacheSelfTest.class);
+        suite.addTestSuite(StatementWithMetaSelfTest.class);
 
         return suite;
     }


### PR DESCRIPTION
Introduced a capability for `H2StatementCache` to attach payload to a statement and such ability is utilized for reusing list of caches (tables) involved in the statement.
Currently, it is used only for `IgniteH2Indexing.mvccTracker`. It could be used in more places but I am not sure if it is necessary at the moment.
Also, I store a list of caches involved in a query, but it looks like that we can simply remember validation result (all caches have same mvcc flag) and an mvcc enabled flag if validation passes. Am I missing something?